### PR TITLE
POSTGIS extension enabled

### DIFF
--- a/terraform/azure/db/terraform.tf
+++ b/terraform/azure/db/terraform.tf
@@ -34,6 +34,15 @@ resource "azurerm_postgresql_flexible_server" "main_server" {
     password_auth_enabled = true
   }
 }
+
+
+resource "azurerm_postgresql_flexible_server_configuration" "postgis" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.main_server.id
+  value     = "POSTGIS"
+}
+
+
 resource "azurerm_postgresql_flexible_server_database" "psql_database" {
   name      = var.psql_database_name
   server_id = azurerm_postgresql_flexible_server.main_server.id


### PR DESCRIPTION
Issues solved: #1 and #7 

Enables the POSTGIS extension for the PostgreSQL server for spatial queries.